### PR TITLE
Increase sensitivity of output

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -32,7 +32,7 @@ actions:
     needs:
     - measures
     outputs:
-      moderately_sensitive:
+      highly_sensitive:
         feather: output/measures/*.feather
 
   standardise:
@@ -50,7 +50,7 @@ actions:
     needs:
     - process_measures
     outputs:
-      moderately_sensitive:
+      highly_sensitive:
         feather: output/standardised/*.feather
         jpg: output/standardised/*.jpeg
 


### PR DESCRIPTION
Two actions were failing with a validation error. I think this is because feather files must now be written to L3, and not L4, because it's hard to interrogate them. Increasing the sensitivity of the output from `moderately_sensitive` to `highly_sensitive` addresses the validation error.